### PR TITLE
Add function-based blog creation view, route, and form wiring

### DIFF
--- a/blogs/urls.py
+++ b/blogs/urls.py
@@ -1,8 +1,10 @@
 from django.urls import path
-from django.contrib.auth import views as auth_views
-from .views import signup_view
+from .views import signup_view, home_view, blog_create_view
+
+app_name = 'blogs'
 
 
 urlpatterns = [
-    
+    path('', home_view, name='home'),
+    path('create/', blog_create_view, name='create'),
 ]

--- a/blogs/views.py
+++ b/blogs/views.py
@@ -1,8 +1,10 @@
-from django.shortcuts import render
+from django.shortcuts import render, redirect
 from django.contrib.auth import views as auth_views
 from django.views.generic import CreateView, ListView
+from django.contrib.auth.decorators import login_required
 
-from .models import User, BlogPost
+from .models import BlogPost
+from django.contrib.auth.models import User
 from .forms import BlogPostForm
 
 def signup_view(request):
@@ -37,3 +39,29 @@ class BlogPostCreateView(CreateView):
     model = BlogPost
     form_class = BlogPostForm
     
+
+@login_required
+def blog_create_view(request):
+    """
+    Function-based view to create a new blog post.
+    Handles form rendering, validation, and saving with proper author/status.
+    """
+    if request.method == 'POST':
+        form = BlogPostForm(request.POST)
+        if form.is_valid():
+            blog_post = form.save(commit=False)
+            blog_post.author = request.user
+
+            # Determine status based on which button was clicked
+            if 'publish' in request.POST:
+                blog_post.status = 'published'
+            else:
+                # Default to draft when "save_draft" or generic submit happens
+                blog_post.status = 'draft'
+
+            blog_post.save()
+            return redirect('blogs:home')
+    else:
+        form = BlogPostForm()
+
+    return render(request, 'blogs/blog_form.html', { 'form': form })


### PR DESCRIPTION
- Implemented a function-based blog creation flow with validation and author assignment. 
- Also Added routes under the blogs namespace and ensured the form template is wired for draft/publish actions. 
- Users can now create and publish blog posts via /blogs/create/.

This PR is for issue https://github.com/MSTC-DA-IICT/Hacktoberfest2k25_BlogNest_Django/issues/6